### PR TITLE
cuda: fix compatibility with torch 2.6

### DIFF
--- a/flash_attention_cuda/csrc/flash_attention.cu
+++ b/flash_attention_cuda/csrc/flash_attention.cu
@@ -355,7 +355,7 @@ torch::Tensor flash_attention_v1_cuda(torch::Tensor q, torch::Tensor k,
   // We need a way of determining at runtime what type a tensor is and then
   // selectively call functions with the corresponding correct type signature.
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      q.type(), "flash_attn_v1", ([&] {
+      q.scalar_type(), "flash_attn_v1", ([&] {
         FWD_HEADDIM_SWITCH(dim, [&]{
             flash_attention_v1_kernel<scalar_t, Bc, Br, kHeadDim>
                 <<<grid, block>>>(q.data_ptr<scalar_t>(), k.data_ptr<scalar_t>(),
@@ -408,7 +408,7 @@ torch::Tensor flash_attention_v2_cuda(torch::Tensor q, torch::Tensor k,
   // NOTE: AT_DISPATCH_FLOATING_TYPES_AND_HALF(TYPE, NAME, ...)
   // We need a way of determining at runtime what type a tensor is and then
   // selectively call functions with the corresponding correct type signature.
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(q.type(), "flash_attn_v2", ([&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(q.scalar_type(), "flash_attn_v2", ([&] {
     FWD_HEADDIM_SWITCH(dim, [&]{
       flash_attention_v2_kernel<scalar_t, Bc, Br, kHeadDim><<<grid, block>>>(
           q.data_ptr<scalar_t>(), k.data_ptr<scalar_t>(),


### PR DESCRIPTION
When building flash_attention_cuda with PyTorch 2.6.0, CUDA compilation errors occur with the message:
```txt
error: no suitable conversion function from "const at::DeprecatedTypeProperties" to "c10::ScalarType" exists
```
This is due to the deprecation of the behavior of `.type()` in PyTorch 2.6.0, which previously could be used with `AT_DISPATCH_FLOATING_TYPES_AND_HALF` macro.
To avoid this error, we should replace all occurences of `.type()` with `.scalar_type()`.

Reference: https://github.com/NVIDIAGameWorks/kaolin/issues/865